### PR TITLE
Schlüssel für Auslieferungs-Schnittstelle verwenden

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,19 +1,16 @@
-name: Build and deploy
+name: Deploy changes
 
 on:
   push:
-    branches:
-      - master
-  pull_request:
     branches:
       - master
   workflow_dispatch:
 
 jobs:
   update:
-    name: update
     runs-on: ubuntu-latest
     steps:
-    - uses: wei/curl@v1
-      with:
-        args: https://l3p3.de/svr/site-update.txt?site=Hoffsite
+    - name: update
+      run: |
+        echo "::add-mask::${{ secrets.UPDATE_KEY }}"
+        curl -X POST -d "site=Hoffsite&key=${{ secrets.UPDATE_KEY }}" https://l3p3.de/svr/site-update.txt


### PR DESCRIPTION
Bisher konnte jeder Hans und Franz meine schöne Update-API ansprechen, was Interaktionen mit GitHub-Servern bewirkte.
Will mich nicht um GitHub-Abkühlungen kümmern müssen, also habe ich einen :key: pro Seite eingeführt!

Wir wollen ja, dass der Spiegel [hff.l3p3.de](https://hff.l3p3.de) weiterhin aktuell bleibt!